### PR TITLE
Support 35mm equivalent focal length

### DIFF
--- a/web/src/core/exif-metadata/exif-metadata.ts
+++ b/web/src/core/exif-metadata/exif-metadata.ts
@@ -5,17 +5,18 @@ class ExifMetadata {
   public model: string | undefined;
   public lensModel: string | undefined;
   public focalLength: string | undefined;
+  public focalLengthIn35mmFilm: string | undefined;
   public fNumber: string | undefined;
   public iso: string | undefined;
   public exposureTime: string | undefined;
   public thumbnail: string | undefined;
 
   constructor(metadata: Tags) {
-    console.log(metadata);
     this.make = metadata?.Make?.description;
     this.model = metadata?.Model?.description;
     this.lensModel = this.model ? metadata?.LensModel?.description?.replace(this.model, '')?.trim() : metadata?.LensModel?.description;
     this.focalLength = metadata?.FocalLength?.description?.replace(' mm', 'mm');
+    this.focalLengthIn35mmFilm = metadata?.FocalLengthIn35mmFilm?.description ? metadata?.FocalLengthIn35mmFilm?.description + 'mm' : undefined;
     this.fNumber = metadata?.FNumber?.description;
     this.iso = metadata?.ISOSpeedRatings?.value?.toString();
     this.exposureTime = metadata?.ExposureTime?.description;

--- a/web/src/core/photo.ts
+++ b/web/src/core/photo.ts
@@ -98,6 +98,20 @@ class Photo {
   }
 
   /**
+   * Returns the equivalent focal length of the photo, assuming a 35mm film.
+   */
+  public get focalLengthIn35mmFilm(): string | undefined {
+    return this.metadata.focalLengthIn35mmFilm;
+  }
+
+  /**
+   * Sets the equivalent focal length of the photo, assuming a 35mm film.
+   */
+  public set focalLengthIn35mmFilm(value: string | undefined) {
+    this.metadata.focalLengthIn35mmFilm = value;
+  }
+
+  /**
    * Returns the F number of the camera that took the photo.
    * @example 'f/4'
    */


### PR DESCRIPTION
This PR (will) fixes #118, by introducing 35mm equivalent focal length data.

I don't have any idea about how to use this property yet, but we may need to flag or preference for that, like [the suggestion](https://github.com/yurucam/exif-frame/issues/118#issuecomment-2056743540).