### PR TITLE
라이트룸을 거치지 않은 사진들의 경우 촬영일시 메타데이터가 공란인 버그 (For photos that have not gone through the lightroom, the shooting date and time metadata is blank)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.97",
+  "version": "0.4.98",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/core/exif-metadata/exif-metadata.ts
+++ b/web/src/core/exif-metadata/exif-metadata.ts
@@ -29,7 +29,12 @@ class ExifMetadata {
     this.iso = metadata?.ISOSpeedRatings?.value ? 'ISO' + metadata?.ISOSpeedRatings?.value?.toString() : undefined;
     this.exposureTime = metadata?.ExposureTime?.description ? metadata?.ExposureTime?.description + 's' : undefined;
     this.thumbnail = metadata?.Thumbnail?.base64 ? 'data:image/jpg;base64,' + metadata?.Thumbnail?.base64 : undefined;
-    this.takenAt = metadata?.DateCreated?.description;
+
+    if (metadata?.DateTime?.description) {
+      const yyyymmdd = metadata.DateTime.description.split(' ')[0].split(':').join('-');
+      const hhmmss = metadata.DateTime.description.split(' ')[1];
+      this.takenAt = `${yyyymmdd} ${hhmmss}`;
+    }
   }
 }
 


### PR DESCRIPTION
https://github.com/yurucam/exif-frame/issues/276