### PR TITLE
refactor: refresh_token 테이블명을 refreshToken으로 변경

### DIFF
--- a/backend/src/extensions/kysely/kysely.database.ts
+++ b/backend/src/extensions/kysely/kysely.database.ts
@@ -3,5 +3,5 @@ import { RefreshTokenModel } from './models/refresh-token.model';
 
 export interface Database {
   member: MemberModel;
-  refresh_token: RefreshTokenModel;
+  refreshToken: RefreshTokenModel;
 }

--- a/backend/src/extensions/kysely/kysely.extension.ts
+++ b/backend/src/extensions/kysely/kysely.extension.ts
@@ -1,13 +1,14 @@
 import { Hono } from 'hono';
 import { D1Dialect } from 'kysely-d1';
-import { CamelCasePlugin, Kysely } from 'kysely';
+import { Kysely } from 'kysely';
 import { Bindings } from '../../types';
 
 export async function kyselyExtension(app: Hono<Bindings>): Promise<void> {
   app.use(async (c, next) => {
     c.env.db = new Kysely({
-      dialect: new D1Dialect({ database: c.env.DB }),
-      plugins: [new CamelCasePlugin()],
+      dialect: new D1Dialect({
+        database: c.env.DB,
+      }),
     });
     await next();
   });

--- a/backend/src/extensions/kysely/migrations/003_rename_refresh_token_to_refreshToken.sql
+++ b/backend/src/extensions/kysely/migrations/003_rename_refresh_token_to_refreshToken.sql
@@ -1,0 +1,40 @@
+-- npx wrangler d1 execute exif-frame --local --file=./src/extensions/kysely/migrations/003_rename_refresh_token_to_refreshToken.sql
+
+-- Drop existing indexes and trigger
+DROP INDEX IF EXISTS idx_refresh_token_token;
+DROP INDEX IF EXISTS idx_refresh_token_member_id;
+DROP INDEX IF EXISTS idx_refresh_token_expires_at;
+DROP TRIGGER IF EXISTS update_refresh_token_updated_at;
+
+-- Create new refreshToken table
+CREATE TABLE refreshToken (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    createdAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updatedAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    token VARCHAR(255) NOT NULL UNIQUE,
+    memberId INTEGER NOT NULL,
+    expiresAt TIMESTAMP NOT NULL,
+    isRevoked BOOLEAN NOT NULL DEFAULT FALSE,
+    FOREIGN KEY (memberId) REFERENCES member(id) ON DELETE CASCADE
+);
+
+-- Copy data from old table to new table
+INSERT INTO refreshToken (id, createdAt, updatedAt, token, memberId, expiresAt, isRevoked)
+SELECT id, createdAt, updatedAt, token, memberId, expiresAt, isRevoked
+FROM refresh_token;
+
+-- Drop old table
+DROP TABLE refresh_token;
+
+-- Create indexes for better query performance
+CREATE INDEX idx_refreshToken_token ON refreshToken(token);
+CREATE INDEX idx_refreshToken_member_id ON refreshToken(memberId);
+CREATE INDEX idx_refreshToken_expires_at ON refreshToken(expiresAt);
+
+-- Create trigger to automatically update updatedAt timestamp
+CREATE TRIGGER update_refreshToken_updated_at
+    AFTER UPDATE ON refreshToken
+    FOR EACH ROW
+BEGIN
+    UPDATE refreshToken SET updatedAt = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;

--- a/backend/src/utils/token.util.ts
+++ b/backend/src/utils/token.util.ts
@@ -211,7 +211,7 @@ export async function storeRefreshToken(
   const db = context.env.db;
 
   const result = await db
-    .insertInto('refresh_token')
+    .insertInto('refreshToken')
     .values({
       token,
       memberId,
@@ -234,7 +234,7 @@ export async function getRefreshTokenFromDB(context: Context<{ Bindings: Env }>,
   const db = context.env.db;
 
   return await db
-    .selectFrom('refresh_token')
+    .selectFrom('refreshToken')
     .selectAll()
     .where('token', '=', token)
     .where('isRevoked', '=', false)
@@ -250,7 +250,7 @@ export async function getRefreshTokenFromDB(context: Context<{ Bindings: Env }>,
 export async function revokeRefreshToken(context: Context<{ Bindings: Env }>, tokenId: number): Promise<void> {
   const db = context.env.db;
 
-  await db.updateTable('refresh_token').set({ isRevoked: true }).where('id', '=', tokenId).execute();
+  await db.updateTable('refreshToken').set({ isRevoked: true }).where('id', '=', tokenId).execute();
 }
 
 /**
@@ -261,5 +261,5 @@ export async function revokeRefreshToken(context: Context<{ Bindings: Env }>, to
 export async function revokeAllRefreshTokens(context: Context<{ Bindings: Env }>, memberId: number): Promise<void> {
   const db = context.env.db;
 
-  await db.updateTable('refresh_token').set({ isRevoked: true }).where('memberId', '=', memberId).execute();
+  await db.updateTable('refreshToken').set({ isRevoked: true }).where('memberId', '=', memberId).execute();
 }


### PR DESCRIPTION
- kysely.database.ts: refresh_token을 refreshToken으로 변경
- token.util.ts: 모든 테이블 참조를 refreshToken으로 변경
- 003_rename_refresh_token_to_refreshToken.sql: 마이그레이션 파일 추가
  - 기존 데이터 보존하며 테이블명 변경
  - 인덱스 및 트리거 재생성