### PR TITLE
feat: Add optional drop shadow to padded frame themes

### DIFF
--- a/web/src/core/drawing/sandbox.ts
+++ b/web/src/core/drawing/sandbox.ts
@@ -7,12 +7,28 @@ interface SandboxOptions {
   padding: { top: number; bottom: number; left: number; right: number };
   targetRatio: string;
   notCroppedMode: boolean;
+  /** Soft drop shadow cast by the photo onto the mat (padding). 0 = off, 10 = strongest. Optional. */
+  shadow?: number;
 }
 
 const sandbox = (photo: Photo, options: SandboxOptions): HTMLCanvasElement => {
   const { image } = photo;
-  const { backgroundColor, padding, targetRatio, notCroppedMode } = options;
+  const { backgroundColor, padding, targetRatio, notCroppedMode, shadow = 0 } = options;
   const { top, bottom, left, right } = padding;
+
+  // Draw the photo with a soft drop shadow onto the surrounding mat (the padding).
+  // Blur and offset scale with the image and are clamped to the smallest mat, so the
+  // shadow always fades out within the frame and never clips at the canvas edge.
+  // No mat (padding 0, e.g. PADDING_INSIDE) => no shadow.
+  const applyPhotoShadow = (ctx: CanvasRenderingContext2D, imageWidth: number): void => {
+    const mat = Math.min(top, bottom, left, right);
+    if (shadow <= 0 || mat <= 0) return;
+    const s = Math.min(Math.max(shadow, 0), 10) / 10;
+    const blur = Math.min(imageWidth * (0.03 + s * 0.12), mat * 0.45);
+    ctx.shadowColor = `rgba(0, 0, 0, ${0.12 + s * 0.5})`;
+    ctx.shadowBlur = blur;
+    ctx.shadowOffsetY = Math.min(blur * 0.6, Math.max(0, bottom - blur * 2));
+  };
 
   const canvas = document.createElement('canvas');
 
@@ -34,7 +50,10 @@ const sandbox = (photo: Photo, options: SandboxOptions): HTMLCanvasElement => {
     const context = canvas.getContext('2d')!;
     context.fillStyle = backgroundColor;
     context.fillRect(0, 0, canvas.width, canvas.height);
+    context.save();
+    applyPhotoShadow(context, imageWidth);
     context.drawImage(image, left, top, imageWidth, imageHeight);
+    context.restore();
   } else {
     const ratio = targetRatio.split(':').map((value) => Number(value));
 
@@ -83,6 +102,8 @@ const sandbox = (photo: Photo, options: SandboxOptions): HTMLCanvasElement => {
         } else {
           imageWidth = (image.width / image.height) * imageHeight;
         }
+        context.save();
+        applyPhotoShadow(context, imageWidth);
         context.drawImage(
           image,
           0,
@@ -94,6 +115,7 @@ const sandbox = (photo: Photo, options: SandboxOptions): HTMLCanvasElement => {
           imageWidth,
           imageHeight
         );
+        context.restore();
       } else {
         let imageWidth = canvas.width - left - right;
         let imageHeight = canvas.height - top - bottom;
@@ -102,6 +124,8 @@ const sandbox = (photo: Photo, options: SandboxOptions): HTMLCanvasElement => {
         } else {
           imageWidth = (image.width / image.height) * imageHeight;
         }
+        context.save();
+        applyPhotoShadow(context, imageWidth);
         context.drawImage(
           image,
           0,
@@ -113,6 +137,7 @@ const sandbox = (photo: Photo, options: SandboxOptions): HTMLCanvasElement => {
           imageWidth,
           imageHeight
         );
+        context.restore();
       }
     }
   }

--- a/web/src/themes/02_JUST_FRAME/index.ts
+++ b/web/src/themes/02_JUST_FRAME/index.ts
@@ -9,6 +9,7 @@ const JUST_FRAME_OPTIONS: ThemeOption[] = [
   { id: 'PADDING_BOTTOM', type: 'number', default: 100, description: 'px' },
   { id: 'PADDING_LEFT', type: 'number', default: 100, description: 'px' },
   { id: 'PADDING_RIGHT', type: 'number', default: 100, description: 'px' },
+  { id: 'SHADOW', type: 'range-slider', min: 0, max: 10, step: 1, default: 0, description: '0 (off) ~ 10' },
 ];
 
 const JUST_FRAME_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store) => {
@@ -17,12 +18,14 @@ const JUST_FRAME_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store
   const PADDING_BOTTOM = input.get('PADDING_BOTTOM') as number;
   const PADDING_LEFT = input.get('PADDING_LEFT') as number;
   const PADDING_RIGHT = input.get('PADDING_RIGHT') as number;
+  const SHADOW = input.get('SHADOW') as number;
 
   return sandbox(photo, {
     targetRatio: store.ratio,
     notCroppedMode: store.notCroppedMode,
     backgroundColor: BACKGROUND_COLOR,
     padding: { top: PADDING_TOP, right: PADDING_RIGHT, bottom: PADDING_BOTTOM, left: PADDING_LEFT },
+    shadow: SHADOW,
   });
 };
 

--- a/web/src/themes/03_ONE_LINE/index.ts
+++ b/web/src/themes/03_ONE_LINE/index.ts
@@ -12,6 +12,7 @@ const ONE_LINE_OPTIONS: ThemeOption[] = [
   { id: 'PADDING_BOTTOM', type: 'number', default: 250, description: 'px' },
   { id: 'PADDING_LEFT', type: 'number', default: 100, description: 'px' },
   { id: 'PADDING_RIGHT', type: 'number', default: 100, description: 'px' },
+  { id: 'SHADOW', type: 'range-slider', min: 0, max: 10, step: 1, default: 0, description: '0 (off) ~ 10' },
   { id: 'TEXT_COLOR', type: 'color', default: '#000000', description: '#ffffff is white, #000000 is black' },
   { id: 'TEXT_ALPHA', type: 'range-slider', default: 1, min: 0, max: 1, step: 0.01, description: '0 - 1' },
   { id: 'TEXT_ALIGN', type: 'select', options: ['center', 'right', 'left'], default: 'center', description: 'left or center or right' },
@@ -41,12 +42,14 @@ const ONE_LINE_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: 
   const TOP_LABEL = (input.get('TOP_LABEL') as string).trim();
   const DIVIDER = (input.get('DIVIDER') as string).trim();
   const TEMPLATE = (input.get('TEMPLATE') as string).trim();
+  const SHADOW = input.get('SHADOW') as number;
 
   const canvas = sandbox(photo, {
     targetRatio: store.ratio,
     notCroppedMode: store.notCroppedMode,
     backgroundColor: BACKGROUND_COLOR,
     padding: PADDING_INSIDE ? { top: 0, right: 0, bottom: 0, left: 0 } : { top: PADDING_TOP, right: PADDING_RIGHT, bottom: PADDING_BOTTOM, left: PADDING_LEFT },
+    shadow: SHADOW,
   });
 
   const context = canvas.getContext('2d')!;

--- a/web/src/themes/04_TWO_LINE/index.ts
+++ b/web/src/themes/04_TWO_LINE/index.ts
@@ -12,6 +12,7 @@ const TWO_LINE_OPTIONS: ThemeOption[] = [
   { id: 'PADDING_BOTTOM', type: 'number', default: 350, description: 'px' },
   { id: 'PADDING_LEFT', type: 'number', default: 100, description: 'px' },
   { id: 'PADDING_RIGHT', type: 'number', default: 100, description: 'px' },
+  { id: 'SHADOW', type: 'range-slider', min: 0, max: 10, step: 1, default: 0, description: '0 (off) ~ 10' },
   { id: 'TEXT_COLOR', type: 'color', default: '#000000', description: '#ffffff is white, #000000 is black' },
   { id: 'TEXT_ALPHA', type: 'range-slider', default: 1, min: 0, max: 1, step: 0.01, description: '0 - 1' },
   { id: 'TEXT_ALIGN', type: 'select', options: ['center', 'right', 'left'], default: 'center', description: 'left or center or right' },
@@ -43,12 +44,14 @@ const TWO_LINE_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: 
   const DIVIDER = (input.get('DIVIDER') as string).trim();
   const TEMPLATE1 = (input.get('TEMPLATE1') as string).trim();
   const TEMPLATE2 = (input.get('TEMPLATE2') as string).trim();
+  const SHADOW = input.get('SHADOW') as number;
 
   const canvas = sandbox(photo, {
     targetRatio: store.ratio,
     notCroppedMode: store.notCroppedMode,
     backgroundColor: BACKGROUND_COLOR,
     padding: PADDING_INSIDE ? { top: 0, right: 0, bottom: 0, left: 0 } : { top: PADDING_TOP, right: PADDING_RIGHT, bottom: PADDING_BOTTOM, left: PADDING_LEFT },
+    shadow: SHADOW,
   });
 
   const context = canvas.getContext('2d')!;

--- a/web/src/themes/06_SHOT_ON_TWO_LINE/index.ts
+++ b/web/src/themes/06_SHOT_ON_TWO_LINE/index.ts
@@ -10,6 +10,7 @@ const SHOT_ON_TWO_LINE_OPTIONS: ThemeOption[] = [
   { id: 'PADDING_BOTTOM', type: 'number', default: 300, description: 'px' },
   { id: 'PADDING_LEFT', type: 'number', default: 50, description: 'px' },
   { id: 'PADDING_RIGHT', type: 'number', default: 50, description: 'px' },
+  { id: 'SHADOW', type: 'range-slider', min: 0, max: 10, step: 1, default: 0, description: '0 (off) ~ 10' },
   { id: 'TEXT_COLOR', type: 'color', default: '#000000', description: '#ffffff is white, #000000 is black' },
   { id: 'TOP_LABEL', type: 'string', default: '', description: 'ex. @username' },
 ];
@@ -22,12 +23,14 @@ const SHOT_ON_TWO_LINE_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput,
   const PADDING_RIGHT = input.get('PADDING_RIGHT') as number;
   const TEXT_COLOR = input.get('TEXT_COLOR') as string;
   const TOP_LABEL = (input.get('TOP_LABEL') as string).trim();
+  const SHADOW = input.get('SHADOW') as number;
 
   const canvas = sandbox(photo, {
     targetRatio: store.ratio,
     notCroppedMode: store.notCroppedMode,
     backgroundColor: BACKGROUND_COLOR,
     padding: { top: PADDING_TOP, right: PADDING_RIGHT, bottom: PADDING_BOTTOM, left: PADDING_LEFT },
+    shadow: SHADOW,
   });
 
   const context = canvas.getContext('2d')!;

--- a/web/src/themes/16_SIMPLE/index.ts
+++ b/web/src/themes/16_SIMPLE/index.ts
@@ -13,6 +13,7 @@ const SIMPLE_OPTIONS: ThemeOption[] = [
   { id: 'PADDING_BOTTOM', type: 'number', default: 400, description: 'px' },
   { id: 'PADDING_LEFT', type: 'number', default: 100, description: 'px' },
   { id: 'PADDING_RIGHT', type: 'number', default: 100, description: 'px' },
+  { id: 'SHADOW', type: 'range-slider', min: 0, max: 10, step: 1, default: 0, description: '0 (off) ~ 10' },
 ];
 
 const SIMPLE_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: Store) => {
@@ -23,12 +24,14 @@ const SIMPLE_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: St
   const PADDING_BOTTOM = input.get('PADDING_BOTTOM') as number;
   const PADDING_LEFT = input.get('PADDING_LEFT') as number;
   const PADDING_RIGHT = input.get('PADDING_RIGHT') as number;
+  const SHADOW = input.get('SHADOW') as number;
 
   const canvas = sandbox(photo, {
     targetRatio: store.ratio,
     notCroppedMode: store.notCroppedMode,
     backgroundColor: '#ffffff',
     padding: PADDING_INSIDE ? { top: 0, right: 0, bottom: 0, left: 0 } : { top: PADDING_TOP, right: PADDING_RIGHT, bottom: PADDING_BOTTOM, left: PADDING_LEFT },
+    shadow: SHADOW,
   });
 
   const context = canvas.getContext('2d')!;


### PR DESCRIPTION
## What

Adds an optional **Shadow** control to the themes that frame the photo with a mat (padding) on all four sides — **Just frame, One line, Two line, Shot on two line, and Simple**. It renders a soft drop shadow cast by the photo onto the mat, giving the framed photo a sense of depth (like a printed photo resting on a mat).

## How

- Implemented once in the shared `sandbox()` drawing helper (`web/src/core/drawing/sandbox.ts`) and inherited by each padded theme, instead of duplicated per theme.
- Each of the five themes exposes a `SHADOW` range slider (**0–10**).
- Blur and offset scale with the image size (resolution-independent) and are **clamped to the smallest padding**, so the shadow always fades out within the frame and never clips at the canvas edge.
- Applied in **free** and **not-cropped** modes. In fixed-ratio *cropped* mode the photo fills the frame edge-to-edge (no even mat), so no shadow is drawn there.

## Behavior / compatibility

- **Default is `0` (off)** — existing output is unchanged; the shadow only appears when a user raises the slider.
- Themes with no mat (e.g. `PADDING_INSIDE` enabled) draw no shadow, as expected.

## Not included

- **Lightroom** is intentionally left out — its mat defaults to a dark color, where a black drop shadow isn't visible.

## Testing

- `npm run dev` → Theme Settings → one of the five themes → raise the **Shadow** slider; the preview updates live.
- Project type-checks cleanly (`tsc --noEmit`).
