### PR TITLE
Parsed FUJIFILM MakerNote(Film Simulation)

### DIFF
--- a/web/src/core/exif-metadata/exif-metadata.ts
+++ b/web/src/core/exif-metadata/exif-metadata.ts
@@ -1,5 +1,106 @@
 import { Tags } from 'exifreader';
 
+// Fujifilm Film Simulation 태그 ID → 이름 매핑
+const FUJI_FILM_SIMULATION: Record<number, string> = {
+  0: 'Provia/Standard',
+  256: 'Velvia/Vivid',
+  512: 'Astia/Soft',
+  768: 'Classic Chrome',
+  1024: 'Pro Neg. Hi',
+  1280: 'Pro Neg. Std',
+  1536: 'Classic Neg.',
+  1792: 'Eterna/Cinema',
+  2048: 'Eterna Bleach Bypass',
+  2304: 'Acros',
+  2560: 'Acros+Ye Filter',
+  2816: 'Acros+R Filter',
+  3072: 'Acros+G Filter',
+  32768: 'Sepia',
+  // Monochrome 계열
+  // ...
+};
+
+/* function parseFujifilmFilmMode(makerNote: unknown): string | undefined {
+  try {
+    // ExifReader가 MakerNote를 ArrayBuffer로 반환
+    const buffer = (makerNote as any)?.value;
+    if (!buffer) return undefined;
+
+    const view = new DataView(
+      buffer instanceof ArrayBuffer ? buffer : buffer.buffer
+    );
+
+    // Fujifilm MakerNote는 "FUJIFILM\x0C\x00\x00\x00" 헤더로 시작
+    // 헤더 12바이트 이후부터 IFD 구조 시작
+    const FUJI_HEADER = 'FUJIFILM';
+    let headerOk = true;
+    for (let i = 0; i < 8; i++) {
+      if (view.getUint8(i) !== FUJI_HEADER.charCodeAt(i)) {
+        headerOk = false;
+        break;
+      }
+    }
+    if (!headerOk) return undefined;
+
+    // IFD offset: little-endian, bytes 8-11
+    const ifdOffset = view.getUint32(8, true);
+    const entryCount = view.getUint16(ifdOffset, true);
+
+    for (let i = 0; i < entryCount; i++) {
+      const entryOffset = ifdOffset + 2 + i * 12;
+      const tagId = view.getUint16(entryOffset, true);
+      if (tagId === 0x1401) {
+        // FilmMode tag
+        const val = view.getUint16(entryOffset + 8, true);
+        return FUJI_FILM_SIMULATION[val] ?? `Unknown (${val})`;
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+} */
+
+function parseFujifilmFilmMode(makerNote: unknown): string | undefined {
+  try {
+    const buffer = (makerNote as any)?.value;
+    
+    if (!buffer) return undefined;
+
+    /* 
+    const view  = new DataView(
+      buffer instanceof ArrayBuffer ? buffer : buffer.buffer
+    ); */
+    const view = new DataView(new Uint8Array(buffer).buffer);
+
+    // 헤더 확인
+    const header = Array.from({length: 8}, (_, i) => String.fromCharCode(view.getUint8(i))).join('');
+    
+    if (header !== 'FUJIFILM') {
+      console.log('[Fuji] 헤더 불일치 - 파싱 중단');
+      return undefined;
+    }
+
+    const ifdOffset = view.getUint32(8, true);
+    const entryCount = view.getUint16(ifdOffset, true);
+
+    for (let i = 0; i < entryCount; i++) {
+      const entryOffset = ifdOffset + 2 + i * 12;
+      const tagId = view.getUint16(entryOffset, true);
+      if (tagId === 0x1401) {
+        const val = view.getUint16(entryOffset + 8, true);
+        return FUJI_FILM_SIMULATION[val] ?? `Unknown (${val})`;
+      }
+    }
+
+    console.log('[Fuji] 0x1401 태그를 찾지 못함');
+    return undefined;
+  } catch (e) {
+    console.error('[Fuji] 파싱 오류:', e);
+    return undefined;
+  }
+}
+
 class ExifMetadata {
   public make: string | undefined;
   public model: string | undefined;
@@ -11,9 +112,11 @@ class ExifMetadata {
   public exposureTime: string | undefined;
   public thumbnail: string | undefined;
   public takenAt: string | undefined;
+  public filmSimulation: string | undefined;
 
   constructor(metadata: Tags) {
     console.log(metadata);
+
     this.make = metadata?.Make?.description;
     this.model = metadata?.Model?.description;
     this.lensModel = this.model ? metadata?.LensModel?.description?.replace(this.model, '')?.trim() : metadata?.LensModel?.description;
@@ -34,6 +137,11 @@ class ExifMetadata {
       const yyyymmdd = metadata.DateTimeOriginal.description.split(' ')[0].split(':').join('-');
       const hhmmss = metadata.DateTimeOriginal.description.split(' ')[1];
       this.takenAt = `${yyyymmdd} ${hhmmss}`;
+    }
+
+    // Fujifilm Film Simulation 추가
+    if (metadata?.Make?.description?.toUpperCase().includes('FUJIFILM')) {
+      this.filmSimulation = parseFujifilmFilmMode(metadata?.MakerNote);
     }
   }
 }

--- a/web/src/core/photo.ts
+++ b/web/src/core/photo.ts
@@ -160,6 +160,14 @@ class Photo {
         return '';
     }
   }
+
+  /**
+   * Returns the film simulation of the camera that took the photo.
+   * @example 'Classic Chrome'
+   */
+  public get filmSimulation(): string {
+    return overrideExifMetadata()?.filmSimulation || this.metadata.filmSimulation || '';
+  }
 }
 
 export default Photo;

--- a/web/src/themes/07_STRAP/index.ts
+++ b/web/src/themes/07_STRAP/index.ts
@@ -64,10 +64,16 @@ const STRAP_OPTIONS: ThemeOption[] = [
   { id: 'PADDING_BOTTOM', type: 'number', default: 0, description: 'px' },
   { id: 'PADDING_LEFT', type: 'number', default: 0, description: 'px' },
   { id: 'PADDING_RIGHT', type: 'number', default: 0, description: 'px' },
+  /*
   { id: 'TEMPLATE1', type: 'string', default: '{ISO}{MM}{F}{SEC}' },
   { id: 'TEMPLATE2', type: 'string', default: '{MAKER}{BODY}' },
   { id: 'TEMPLATE3', type: 'string', default: '{TAKEN_AT}' },
   { id: 'TEMPLATE4', type: 'string', default: '{LENS}' },
+   */
+  { id: 'TEMPLATE1', type: 'string', default: '{ISO}{MM}{F}{SEC}', description: '{ISO} {MM} {F} {SEC} {FILM} {MAKER} {BODY} {LENS} {TAKEN_AT}' },
+  { id: 'TEMPLATE2', type: 'string', default: '{MAKER}{BODY}', description: '{ISO} {MM} {F} {SEC} {FILM} {MAKER} {BODY} {LENS} {TAKEN_AT}' },
+  { id: 'TEMPLATE3', type: 'string', default: '{TAKEN_AT}', description: '{ISO} {MM} {F} {SEC} {FILM} {MAKER} {BODY} {LENS} {TAKEN_AT}' },
+  { id: 'TEMPLATE4', type: 'string', default: '{FILM}', description: '{ISO} {MM} {F} {SEC} {FILM} {MAKER} {BODY} {LENS} {TAKEN_AT}' },
 ];
 
 const STRAP_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: Store) => {
@@ -99,6 +105,7 @@ const STRAP_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: Sto
         .replace(/{F}/g, store.disableExposureMeter ? '' : photo.fNumber || '')
         .replace(/{SEC}/g, store.disableExposureMeter ? '' : photo.exposureTime || '')
         .replace(/{TAKEN_AT}/g, photo.takenAt || '')
+        .replace(/{FILM}/g, photo.filmSimulation || '')
         .replace(/}/g, '')
     )
     .filter(Boolean)
@@ -116,6 +123,7 @@ const STRAP_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: Sto
         .replace(/{F}/g, store.disableExposureMeter ? '' : photo.fNumber || '')
         .replace(/{SEC}/g, store.disableExposureMeter ? '' : photo.exposureTime || '')
         .replace(/{TAKEN_AT}/g, photo.takenAt || '')
+        .replace(/{FILM}/g, photo.filmSimulation || '')
         .replace(/}/g, '')
     )
     .filter(Boolean)
@@ -133,6 +141,7 @@ const STRAP_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: Sto
         .replace(/{F}/g, store.disableExposureMeter ? '' : photo.fNumber || '')
         .replace(/{SEC}/g, store.disableExposureMeter ? '' : photo.exposureTime || '')
         .replace(/{TAKEN_AT}/g, photo.takenAt || '')
+        .replace(/{FILM}/g, photo.filmSimulation || '')
         .replace(/}/g, '')
     )
     .filter(Boolean)
@@ -150,6 +159,7 @@ const STRAP_FUNC: ThemeFunc = (photo: Photo, input: ThemeOptionInput, store: Sto
         .replace(/{F}/g, store.disableExposureMeter ? '' : photo.fNumber || '')
         .replace(/{SEC}/g, store.disableExposureMeter ? '' : photo.exposureTime || '')
         .replace(/{TAKEN_AT}/g, photo.takenAt || '')
+        .replace(/{FILM}/g, photo.filmSimulation || '')
         .replace(/}/g, '')
     )
     .filter(Boolean)


### PR DESCRIPTION
## Summary
Adds support for Fujifilm Film Simulation metadata (e.g. Classic Chrome, Velvia, Acros) by parsing the Fujifilm MakerNote tag `0x1401`.

## Changes
- `exif-metadata.ts`: Parse Fujifilm MakerNote binary to extract Film Simulation value
- `photo.ts`: Add `filmSimulation` getter
- `07_STRAP/index.ts`: Add `{FILM}` template token support

## How it works
ExifReader returns the MakerNote as a raw `number[]` array. This PR converts it to a `DataView`, validates the `FUJIFILM` header, walks the IFD entries, and maps tag `0x1401` to a human-readable film simulation name.

The fix for converting number[] to Uint8Array when creating a DataView from the raw MakerNote buffer is not Fujifilm-specific. ExifReader returns MakerNote data as a number[] array for all manufacturers, so this conversion is a prerequisite for parsing any vendor's MakerNote. Other manufacturers (Canon, Nikon, Sony, etc.) can benefit from this fix as a foundation for adding their own MakerNote support in the future.

## Notes
- Only applies when `Make` contains `FUJIFILM`
- Falls back gracefully to empty string for non-Fujifilm cameras
- Tested with FUJIFILM X100VI